### PR TITLE
chore: change the order of docs: Change the order of readme files

### DIFF
--- a/.github/workflows/publish-ecopass-kit-pdf.yaml
+++ b/.github/workflows/publish-ecopass-kit-pdf.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Generate Documentation.pdf from markdown files
         uses: docker://pandoc/latex:2.9
         with:
-          args: --output=./docs/Documentation.pdf ./docs/page-adoption-view.md ./docs/page-software-development-view.md ./docs/page-software-operation-view.md ./docs/page-documentation.md ./docs/success-stories/BatteryPass_Viewer_App.md
+          args: --output=./docs/Documentation.pdf ./docs/page-documentation.md ./docs/success-stories/BatteryPass_Viewer_App.md  ./docs/page-software-operation-view.md ./docs/page-software-development-view.md ./docs/page-adoption-view.md ./README.md
       
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!-- 
Thanks for your contribution for the Eco Pass! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->



# Linked PR(s):
#33 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
